### PR TITLE
feat: hybrid onboarding review with Go tool + AI judgment

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -33,12 +33,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Get reusable workflow ref
-        id: get-workflow-ref
-        run: |
-          ref="${{ github.workflow_ref }}"
-          echo "ref=${ref##*@}" >> "$GITHUB_OUTPUT"
-
       - name: Checkout reusable-workflows (for deterministic review tool)
         if: |
           contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
@@ -46,7 +40,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: step-security/reusable-workflows
-          ref: ${{ steps.get-workflow-ref.outputs.ref }}
+          ref: ${{ github.job_workflow_sha }}
           path: .reusable-workflows
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: step-security/reusable-workflows
-          ref: ${{ github.job_workflow_sha }}
+          ref: feat/update-review-process
           path: .reusable-workflows
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -165,7 +165,13 @@ jobs:
             If `action_type` is `composite`, also check (the tool already covers "first step contains the subscription URL" — skip that):
               - **All non-official actions are pinned** by SHA, and any with a step-security maintained alternative are swapped.
 
-            **Step 4 — Output one PR comment in this exact structure:**
+            **Step 4 — Output one PR comment in this exact structure.**
+
+            Every verdict MUST begin with one of these three emojis (no exceptions, no alternative emojis like 🔴 / 🟡):
+              · `✅ Pass` — rule clearly satisfied
+              · `⚠️ Needs attention` — ambiguous, partially met, or reviewer should double-check
+              · `❌ Fail` — rule clearly violated
+            For bullet lists under `uses:` versions and `<type>-specific`, prefix EACH bullet with the same emoji.
 
             ```
             ## StepSecurity onboarding review
@@ -174,13 +180,13 @@ jobs:
             Deterministic results are published as a separate check — see the **"StepSecurity onboarding checks"** check in the Checks tab.
 
             ### 🔎 Judgment-call review
-            **License copyright:** <verdict + file:line + 1–2 sentences>
-            **Subscription invoked first:** <verdict + file:line>
-            **Upstream-only workflows removed:** <verdict + list any that should be removed>
-            **`uses:` versions / advisor swaps:** <bullet list of any that need updating>
-            **README major-version tags:** <verdict + file:line of any full-semver tags found>
-            **Security scan:** <verdict + any findings with file:line>
-            **<type>-specific:** <bullet list of pass/fail for each rule above>
+            **License copyright:** <emoji + verdict — file:line + 1–2 sentences>
+            **Subscription invoked first:** <emoji + verdict — file:line>
+            **Upstream-only workflows removed:** <emoji + verdict — list any that should be removed>
+            **`uses:` versions / advisor swaps:** <emoji-prefixed bullets, one per `uses:` reference checked>
+            **README major-version tags:** <emoji + verdict — file:line of any full-semver tags found>
+            **Security scan:** <emoji + verdict — any findings with file:line>
+            **<type>-specific:** <emoji-prefixed bullets, one per rule above>
 
             ### 🐛 Tool sanity check
             <empty if all of the tool's findings looked right; otherwise list each finding you disagree with and why>

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Get reusable workflow ref
+        id: get-workflow-ref
+        run: |
+          ref="${{ github.workflow_ref }}"
+          echo "ref=${ref##*@}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout reusable-workflows (for deterministic review tool)
         if: |
           contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
@@ -40,7 +46,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: step-security/reusable-workflows
-          ref: main
+          ref: ${{ steps.get-workflow-ref.outputs.ref }}
           path: .reusable-workflows
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -21,6 +21,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+      checks: write
 
     steps:
       - name: Harden Runner
@@ -63,27 +64,44 @@ jobs:
             --repo-path "$GITHUB_WORKSPACE" \
             --output "$GITHUB_WORKSPACE/review_report.json"
 
-          {
-            echo "## Onboarding deterministic checks"
-            echo ""
-            python3 - "$GITHUB_WORKSPACE/review_report.json" <<'PY'
-          import json, sys
-          r = json.load(open(sys.argv[1]))
-          s = r["summary"]
-          print(f"- **Action type:** `{r['action_type']}`")
-          print(f"- **Upstream:** `{r['upstream'] or 'unknown'}`")
-          print(f"- **Total:** {s['total']}  |  **Passed:** {s['passed']}  |  **Failed (must):** {s['failed_must']}  |  **Failed (should):** {s['failed_should']}  |  **Skipped:** {s['skipped']}")
-          print()
-          fails = [f for f in r["findings"] if f["status"] == "fail"]
-          if fails:
-              print("### Failures")
-              print("| Severity | Rule | File | Message |")
-              print("|---|---|---|---|")
-              for f in fails:
-                  msg = (f.get("message") or "").replace("|", "\\|")
-                  print(f"| {f['severity']} | `{f['rule_id']}` | `{f.get('file','')}` | {msg} |")
-          PY
-          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Post deterministic summary to GitHub Checks
+        if: |
+          contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
+          !(github.event.pull_request.title == 'chore: Cherry-picked changes from upstream')
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          REPORT_PATH: ${{ github.workspace }}/review_report.json
+        with:
+          script: |
+            const fs = require('fs');
+            const r = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, 'utf8'));
+            const s = r.summary;
+            const emoji = { pass: '✅', fail: '❌', skip: '⏭️' };
+
+            let md = `**Action type:** \`${r.action_type}\`  ·  **Upstream:** \`${r.upstream || 'unknown'}\`\n\n`;
+            md += `✅ ${s.passed} passed · ❌ ${s.failed_must} failed (must) · ⚠️ ${s.failed_should} failed (should) · ⏭️ ${s.skipped} skipped\n\n`;
+            md += `| Status | Severity | Rule | File | Message |\n|---|---|---|---|---|\n`;
+            for (const f of r.findings) {
+              const msg = (f.message || '').replace(/\|/g, '\\|');
+              md += `| ${emoji[f.status] || ''} | ${f.severity} | \`${f.rule_id}\` | \`${f.file || ''}\` | ${msg} |\n`;
+            }
+
+            const conclusion = s.failed_must > 0
+              ? 'failure'
+              : s.failed_should > 0 ? 'neutral' : 'success';
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'StepSecurity onboarding checks',
+              head_sha: context.payload.pull_request.head.sha,
+              status: 'completed',
+              conclusion,
+              output: {
+                title: `${s.passed}/${s.total} passed · ${s.failed_must} must-fix · ${s.failed_should} should-fix`,
+                summary: md,
+              },
+            });
 
       - name: Upload review report
         if: |
@@ -153,17 +171,7 @@ jobs:
             ## StepSecurity onboarding review
 
             **Action type:** `<type>`  ·  **Upstream:** `<owner>/<repo>`
-            **Deterministic:** ✅ N passed · ❌ N failed (must) · ⚠️ N failed (should) · ⏭️ N skipped
-
-            ### ❌ Must-fix (deterministic)
-            | Rule | File | Issue |
-            |---|---|---|
-            | ... | ... | ... |
-
-            ### ⚠️ Should-fix (deterministic)
-            | Rule | File | Issue |
-            |---|---|---|
-            | ... | ... | ... |
+            Deterministic results are published as a separate check — see the **"StepSecurity onboarding checks"** check in the Checks tab.
 
             ### 🔎 Judgment-call review
             **License copyright:** <verdict + file:line + 1–2 sentences>
@@ -181,7 +189,7 @@ jobs:
             <2–3 sentences: ready to merge, or what blocks it>
             ```
 
-            Keep verdicts terse. Cite file:line for every fail. Do not repeat the deterministic table contents in the judgment-call section.
+            Keep verdicts terse. Cite file:line for every fail. Do not render the deterministic findings table — that's in the Checks tab.
 
       - name: Run Claude Code Review (cherry-pick)
         if:  |

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -32,7 +32,70 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
- 
+
+      - name: Checkout reusable-workflows (for deterministic review tool)
+        if: |
+          contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
+          !(github.event.pull_request.title == 'chore: Cherry-picked changes from upstream')
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: step-security/reusable-workflows
+          ref: main
+          path: .reusable-workflows
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        if: |
+          contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
+          !(github.event.pull_request.title == 'chore: Cherry-picked changes from upstream')
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.24'
+
+      - name: Run deterministic onboarding checks
+        if: |
+          contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
+          !(github.event.pull_request.title == 'chore: Cherry-picked changes from upstream')
+        id: review-tool
+        working-directory: .reusable-workflows
+        run: |
+          go run ./cmd/review-onboarding \
+            --repo-path "$GITHUB_WORKSPACE" \
+            --output "$GITHUB_WORKSPACE/review_report.json"
+
+          {
+            echo "## Onboarding deterministic checks"
+            echo ""
+            python3 - "$GITHUB_WORKSPACE/review_report.json" <<'PY'
+          import json, sys
+          r = json.load(open(sys.argv[1]))
+          s = r["summary"]
+          print(f"- **Action type:** `{r['action_type']}`")
+          print(f"- **Upstream:** `{r['upstream'] or 'unknown'}`")
+          print(f"- **Total:** {s['total']}  |  **Passed:** {s['passed']}  |  **Failed (must):** {s['failed_must']}  |  **Failed (should):** {s['failed_should']}  |  **Skipped:** {s['skipped']}")
+          print()
+          fails = [f for f in r["findings"] if f["status"] == "fail"]
+          if fails:
+              print("### Failures")
+              print("| Severity | Rule | File | Message |")
+              print("|---|---|---|---|")
+              for f in fails:
+                  msg = (f.get("message") or "").replace("|", "\\|")
+                  print(f"| {f['severity']} | `{f['rule_id']}` | `{f.get('file','')}` | {msg} |")
+          PY
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload review report
+        if: |
+          always() &&
+          contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
+          !(github.event.pull_request.title == 'chore: Cherry-picked changes from upstream')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: review_report
+          path: review_report.json
+          if-no-files-found: ignore
+
       - name: Run Claude Code Review (Default)
         if: |
           contains(join(github.event.pull_request.labels.*.name, ','), 'review-required') &&
@@ -43,46 +106,82 @@ jobs:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide comprehensive feedback.
+            You are reviewing a StepSecurity onboarding PR for a forked GitHub Action.
 
-            Keep following things in mind:
-            
-            Determine whether the action is node based, docker based, composite action or multiple actions of different kinds are present
-            I am listing some common points to review for all actions and some specific points depending on type of action
+            **Step 1 — Read the deterministic report.**
+            A tool has already checked the boolean compliance rules. Read `review_report.json` at the repo root. It has this shape:
+            ```
+            { "action_type": "node|docker|composite|unknown",
+              "upstream": "<owner>/<repo>",
+              "summary": { "total": N, "passed": N, "failed_must": N, "failed_should": N, "skipped": N },
+              "findings": [ { "rule_id", "title", "severity": "must|should", "status": "pass|fail|skip", "file", "message" } ] }
+            ```
 
-            Points to be taken care of for all actions:
-              - License should be present with copyright of step-security as well as original author.
-              - There should be a action.yml file and in that as well author name should be step-security. If the field author-name is not present then ignore.
-              - Security.md file should be present.
-              - FUNDING.yml or funding.yml file should not be present.
-              - .github folder should contain workflows folder and this folder should contain following files
-                - auto_cherry_pick.yml
-                - actions_release.yml
-              - renovate.json file should not be present.
-              - PULL_REQUEST.md file should not be present.
-              - ISSUE_TEMEPLATE folder should not be present.
-              - CHANGELOG.md file should not be present.
-              - .vscode folder should not be present
-              - If Readme.md file contains any part which tells how the action should be used, then make sure that in the example complete semver tag is not used and only major version is used.
-              - Readme.md should contain this banner ![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
-              - Code should contain subscription check and make sure it makes call to this url "https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription" for checking the subscription.
-              - In the subscription check code the value of upstream variable must be similar to the string constructed from original-owner and repo-name properties from .github/workflows/auto_cherry_pick.yml file in following way <original-owner>/<repo-name>
-              - Scan the whole code thoroughly for any existing security vulnerabilities that might be exploited by malicious actors.
+            **Step 2 — Sanity-check the tool's findings.**
+            Spot-check 2–3 of the tool's pass/fail decisions against the actual files (the tool uses regex; it can be wrong). If you find a tool error, call it out explicitly in your comment.
 
-            Specific points for node based actions
-              - author name in package.json file should be step-security. If the field author-name is not present then ignore.
-              - If there is a field named git repository in package.json file then it should contain the phrase step-security. If the field repository is not present then ignore.
-              - None of the dependencies should be unused.
-              - dist folder should be present.
-              - If package.json does not contain the field "build" in the scripts object or the package manager is not npm then check the files .github/workflows/audit_fix.yml and .github/workflows/actions_release.yml, they should contain script as an input.
+            **Step 3 — Cover the judgment-call rules the tool cannot check.**
+            For each item below, look at the actual files and report a verdict (Pass / Fail / Needs attention) with file:line evidence.
 
-            Specific points for docker based actions
-              - The action must use a published docker image
-              - The docker image must be published to step security org
-              - The docker image must be tagged with major version
+            Common (all action types):
+              - **License copyright semantics.** LICENSE must contain a StepSecurity copyright (`Copyright (c) 2026 StepSecurity` or similar). If the upstream license had an original-author copyright, that must still be present *above* the StepSecurity one. Compare against the upstream license at `https://github.com/<upstream>/blob/HEAD/LICENSE` if you need a reference.
+              - **Subscription check is invoked first.** The `validateSubscription()` (or equivalent) call must be the first executable line of the action's entry point — before any other logic runs. Cite the line.
+              - **Upstream-only workflows removed.** Any workflow in `.github/workflows/` that came from upstream and isn't related to code/action testing (release automation, tag updates, PR labelling, stale issues, etc.) must be removed. The required ones are `auto_cherry_pick.yml`, `actions_release.yml`, `audit_package.yml`. Workflows for CI/tests are fine.
+              - **GitHub Actions versions in workflows.** Every `uses:` reference in `.github/workflows/*.yml` should be at its latest major version tag (e.g. `actions/checkout@v6`, `actions/setup-node@v5`). Where a step-security maintained drop-in exists (https://app.stepsecurity.io/action-advisor?tab=maintained — e.g. `docker/login-action` → `step-security/docker-login-action`, `docker/setup-qemu-action` → `step-security/setup-qemu-action`, `docker/setup-buildx-action` → `step-security/setup-buildx-action`, `docker/build-push-action` → `step-security/docker-build-push-action`), the reference must be swapped. **Do not add new steps** that weren't already in the workflow.
+              - **README usage examples.** Usage snippets must use a major-version tag (`@v1`) not a full semver (`@v1.2.3`). Any other actions referenced in usage examples follow the same advisor-swap + latest-major rule as above.
+              - **Security review.** Scan diffs and all new code for: command injection, untrusted input passed to shell, prototype pollution, dependency confusion / typosquats, exposed secrets, `eval`, suspicious `postinstall` scripts, unsafe `pickle`/`yaml.load`, anything that looks like an attempt to exfiltrate `GITHUB_TOKEN`.
 
-            Specific points for composite actions
-              - If the action uses any other action which is not an official github action, make sure it is pinned.
+            If `action_type` is `node`, also check (the tool already covers dist/, .npmrc, node24 runtime, and package.json author/repository — skip those):
+              - **No unused dependencies** in `package.json` (best-effort — grep imports against the dep list).
+              - **Workflow inputs.** Inspect `package.json` and the lockfiles, then check `.github/workflows/audit_package.yml`, `.github/workflows/actions_release.yml`, and `.github/workflows/auto_cherry_pick.yml`:
+                  · `node_version` input must be declared (default `"24"`) and passed to the reusable workflow in **all three** workflows.
+                  · `script` input must be declared and passed in **all three** workflows if any of: `package.json.scripts.build` is missing, package manager is not npm, or the build script does not invoke a bundler (`ncc` / `esbuild` / `webpack` / `rollup` / `tsc` / `tsup` / `vite` / `parcel`).
+                  · `package_manager` input (default `"yarn"`) must be declared and passed in `audit_package.yml` and `auto_cherry_pick.yml` if `yarn.lock` exists.
+                  · `yarn_version` input must be declared and passed in **all three** workflows if `yarn.lock` exists AND yarn is not 1.x (detected by `__metadata:` header in yarn.lock or presence of `.yarnrc.yml`).
+                For each missing input, cite the workflow file and the specific spec condition that triggered the requirement.
+              - **Subscription check code shape.** Must use `axios` (TS: `import axios, {isAxiosError} from 'axios'`; JS: `import axios from 'axios'`). Must include `@actions/github` and `@actions/core` deps. Match the snippet shape in the onboarding spec — in particular flag any raw ESC bytes (the actual unprintable control character) in place of the literal backslash-u-001b escape sequence.
+
+            If `action_type` is `docker`, also check (the tool already covers docker.yml existence and jq-in-Dockerfile — skip those):
+              - **Subscription check location.** If a shell script is invoked by the Dockerfile, the subscription check must live there. If a JS/TS/Python/Go file is invoked, the check must be in that file using the language-appropriate translation.
+
+            If `action_type` is `composite`, also check (the tool already covers "first step contains the subscription URL" — skip that):
+              - **All non-official actions are pinned** by SHA, and any with a step-security maintained alternative are swapped.
+
+            **Step 4 — Output one PR comment in this exact structure:**
+
+            ```
+            ## StepSecurity onboarding review
+
+            **Action type:** `<type>`  ·  **Upstream:** `<owner>/<repo>`
+            **Deterministic:** ✅ N passed · ❌ N failed (must) · ⚠️ N failed (should) · ⏭️ N skipped
+
+            ### ❌ Must-fix (deterministic)
+            | Rule | File | Issue |
+            |---|---|---|
+            | ... | ... | ... |
+
+            ### ⚠️ Should-fix (deterministic)
+            | Rule | File | Issue |
+            |---|---|---|
+            | ... | ... | ... |
+
+            ### 🔎 Judgment-call review
+            **License copyright:** <verdict + file:line + 1–2 sentences>
+            **Subscription invoked first:** <verdict + file:line>
+            **Upstream-only workflows removed:** <verdict + list any that should be removed>
+            **`uses:` versions / advisor swaps:** <bullet list of any that need updating>
+            **README major-version tags:** <verdict + file:line of any full-semver tags found>
+            **Security scan:** <verdict + any findings with file:line>
+            **<type>-specific:** <bullet list of pass/fail for each rule above>
+
+            ### 🐛 Tool sanity check
+            <empty if all of the tool's findings looked right; otherwise list each finding you disagree with and why>
+
+            ### Summary
+            <2–3 sentences: ready to merge, or what blocks it>
+            ```
+
+            Keep verdicts terse. Cite file:line for every fail. Do not repeat the deterministic table contents in the judgment-call section.
 
       - name: Run Claude Code Review (cherry-pick)
         if:  |

--- a/cmd/review-onboarding/main.go
+++ b/cmd/review-onboarding/main.go
@@ -1,0 +1,1287 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+type Severity string
+
+const (
+	SevMust   Severity = "must"
+	SevShould Severity = "should"
+)
+
+type Status string
+
+const (
+	StatusPass Status = "pass"
+	StatusFail Status = "fail"
+	StatusSkip Status = "skip"
+)
+
+type Finding struct {
+	RuleID   string   `json:"rule_id"`
+	Title    string   `json:"title"`
+	Severity Severity `json:"severity"`
+	Status   Status   `json:"status"`
+	File     string   `json:"file,omitempty"`
+	Message  string   `json:"message,omitempty"`
+}
+
+type Summary struct {
+	Total        int `json:"total"`
+	Passed       int `json:"passed"`
+	FailedMust   int `json:"failed_must"`
+	FailedShould int `json:"failed_should"`
+	Skipped      int `json:"skipped"`
+}
+
+type Report struct {
+	ActionType string    `json:"action_type"`
+	Upstream   string    `json:"upstream"`
+	Summary    Summary   `json:"summary"`
+	Findings   []Finding `json:"findings"`
+}
+
+func main() {
+	var repoPath, output, format string
+	var failOnError bool
+	flag.StringVar(&repoPath, "repo-path", ".", "Path to the action repository to review")
+	flag.StringVar(&output, "output", "", "Write report to this file (default: stdout)")
+	flag.StringVar(&format, "format", "json", "Output format: 'json' or 'table'")
+	flag.StringVar(&format, "f", "json", "Output format: 'json' or 'table' (shorthand)")
+	flag.BoolVar(&failOnError, "fail-on-error", false, "Exit 1 if any 'must' rule fails")
+	flag.Parse()
+
+	switch format {
+	case "json", "table":
+	default:
+		fmt.Fprintf(os.Stderr, "invalid --format %q (must be 'json' or 'table')\n", format)
+		os.Exit(2)
+	}
+
+	absRepo, err := filepath.Abs(repoPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to resolve repo path: %v\n", err)
+		os.Exit(2)
+	}
+
+	upstream := readUpstream(absRepo)
+	actionType := detectActionType(absRepo)
+
+	findings := runCommonChecks(absRepo, upstream)
+	findings = append(findings, runTypeChecks(absRepo, actionType)...)
+	sortFindings(findings)
+
+	report := Report{
+		ActionType: actionType,
+		Upstream:   upstream,
+		Findings:   findings,
+		Summary:    summarize(findings),
+	}
+
+	var dst io.Writer = os.Stdout
+	if output != "" {
+		f, err := os.Create(output)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create output file: %v\n", err)
+			os.Exit(2)
+		}
+		defer f.Close()
+		dst = f
+	}
+
+	switch format {
+	case "json":
+		if err := writeJSON(dst, report); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to encode JSON: %v\n", err)
+			os.Exit(2)
+		}
+	case "table":
+		if err := writeTable(dst, report, output == ""); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to render table: %v\n", err)
+			os.Exit(2)
+		}
+	}
+
+	// Summary always goes to stderr so it doesn't pollute stdout when piping.
+	fmt.Fprintf(os.Stderr, "Action type: %s\n", actionType)
+	fmt.Fprintf(os.Stderr, "Upstream:    %s\n", upstream)
+	fmt.Fprintf(os.Stderr, "Total: %d  Passed: %d  Failed (must): %d  Failed (should): %d  Skipped: %d\n",
+		report.Summary.Total, report.Summary.Passed, report.Summary.FailedMust,
+		report.Summary.FailedShould, report.Summary.Skipped)
+
+	if failOnError && report.Summary.FailedMust > 0 {
+		os.Exit(1)
+	}
+}
+
+func writeJSON(w io.Writer, report Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+func writeTable(w io.Writer, report Report, colorize bool) error {
+	if !colorize {
+		text.DisableColors()
+	} else {
+		text.EnableColors()
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Action type: %s\n", report.ActionType)
+	fmt.Fprintf(w, "  Upstream:    %s\n", report.Upstream)
+	s := report.Summary
+	fmt.Fprintf(w, "  Total: %d  Passed: %d  Failed (must): %d  Failed (should): %d  Skipped: %d\n\n",
+		s.Total, s.Passed, s.FailedMust, s.FailedShould, s.Skipped)
+
+	tw := table.NewWriter()
+	tw.SetOutputMirror(w)
+	tw.SetStyle(table.StyleLight)
+	tw.Style().Format.Header = text.FormatDefault
+	tw.AppendHeader(table.Row{"Status", "Severity", "Rule", "File", "Message"})
+
+	for _, f := range report.Findings {
+		tw.AppendRow(table.Row{
+			colorStatus(f.Status),
+			colorSeverity(f.Severity),
+			f.RuleID,
+			f.File,
+			oneLine(f.Message),
+		})
+	}
+
+	tw.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 1, Align: text.AlignLeft},
+		{Number: 2, Align: text.AlignLeft},
+		{Number: 3, Align: text.AlignLeft, WidthMax: 42, WidthMaxEnforcer: text.WrapText},
+		{Number: 4, Align: text.AlignLeft, WidthMax: 30, WidthMaxEnforcer: text.WrapText},
+		{Number: 5, Align: text.AlignLeft, WidthMax: 60, WidthMaxEnforcer: text.WrapText},
+	})
+
+	tw.Render()
+	return nil
+}
+
+func colorStatus(s Status) string {
+	switch s {
+	case StatusPass:
+		return text.FgGreen.Sprint("PASS")
+	case StatusFail:
+		return text.FgHiRed.Sprint("FAIL")
+	case StatusSkip:
+		return text.FgYellow.Sprint("SKIP")
+	}
+	return strings.ToUpper(string(s))
+}
+
+func colorSeverity(s Severity) string {
+	switch s {
+	case SevMust:
+		return text.FgRed.Sprint("must")
+	case SevShould:
+		return text.FgYellow.Sprint("should")
+	}
+	return string(s)
+}
+
+// oneLine collapses newlines so a message stays on a single row before wrap.
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
+func summarize(findings []Finding) Summary {
+	s := Summary{Total: len(findings)}
+	for _, f := range findings {
+		switch f.Status {
+		case StatusPass:
+			s.Passed++
+		case StatusSkip:
+			s.Skipped++
+		case StatusFail:
+			if f.Severity == SevMust {
+				s.FailedMust++
+			} else {
+				s.FailedShould++
+			}
+		}
+	}
+	return s
+}
+
+// ---------- upstream + action type detection ----------
+
+func readUpstream(repoPath string) string {
+	for _, name := range []string{"auto_cherry_pick.yml", "auto_cherry_pick.yaml"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, ".github", "workflows", name))
+		if err != nil {
+			continue
+		}
+		owner := extractYAMLValue(string(data), "original-owner")
+		repo := extractYAMLValue(string(data), "repo-name")
+		if owner != "" && repo != "" {
+			return owner + "/" + repo
+		}
+	}
+	return ""
+}
+
+func detectActionType(repoPath string) string {
+	var content string
+	for _, name := range []string{"action.yml", "action.yaml"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			continue
+		}
+		content = string(data)
+		break
+	}
+	if content == "" {
+		return "unknown"
+	}
+	using := strings.ToLower(extractYAMLValue(content, "using"))
+	switch {
+	case strings.HasPrefix(using, "node"):
+		return "node"
+	case using == "docker":
+		return "docker"
+	case using == "composite":
+		return "composite"
+	}
+	if regexp.MustCompile(`(?m)^\s*image:\s*`).MatchString(content) {
+		return "docker"
+	}
+	return "unknown"
+}
+
+func extractYAMLValue(content, key string) string {
+	re := regexp.MustCompile(fmt.Sprintf(`(?m)^\s*%s:\s*["']?([^"'\n#]+?)["']?\s*(#.*)?$`, regexp.QuoteMeta(key)))
+	m := re.FindStringSubmatch(content)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// ---------- common rule runner ----------
+
+func runCommonChecks(repoPath, upstream string) []Finding {
+	var findings []Finding
+
+	findings = append(findings, checkLicense(repoPath))
+	findings = append(findings, checkActionYMLAuthor(repoPath))
+	findings = append(findings, checkSecurityMD(repoPath))
+	findings = append(findings, checkRequiredWorkflows(repoPath)...)
+	findings = append(findings, checkAbsent(repoPath, forbiddenPaths())...)
+	findings = append(findings, checkPreCommitTooling(repoPath)...)
+	findings = append(findings, checkBanner(repoPath))
+	findings = append(findings, checkSubscriptionURL(repoPath))
+	findings = append(findings, checkSubscriptionUpstream(repoPath, upstream))
+	findings = append(findings, checkDocsUpstreamRefs(repoPath, upstream))
+	findings = append(findings, checkNoUnauthorizedSchedules(repoPath)...)
+
+	return findings
+}
+
+// ---------- type-specific rule runner ----------
+
+func runTypeChecks(repoPath, actionType string) []Finding {
+	switch actionType {
+	case "node":
+		return runNodeChecks(repoPath)
+	case "docker":
+		return runDockerChecks(repoPath)
+	case "composite":
+		return runCompositeChecks(repoPath)
+	}
+	return nil
+}
+
+func sortFindings(findings []Finding) {
+	sevOrder := map[Status]int{StatusFail: 0, StatusSkip: 1, StatusPass: 2}
+	sort.SliceStable(findings, func(i, j int) bool {
+		if sevOrder[findings[i].Status] != sevOrder[findings[j].Status] {
+			return sevOrder[findings[i].Status] < sevOrder[findings[j].Status]
+		}
+		if findings[i].Severity != findings[j].Severity {
+			return findings[i].Severity == SevMust
+		}
+		return findings[i].RuleID < findings[j].RuleID
+	})
+}
+
+// ---------- individual checks ----------
+
+func checkLicense(repoPath string) Finding {
+	rule := "common.license_present"
+	for _, c := range []string{"LICENSE", "LICENSE.md", "LICENSE.txt"} {
+		if _, err := os.Stat(filepath.Join(repoPath, c)); err == nil {
+			return Finding{
+				RuleID:   rule,
+				Title:    "LICENSE file present",
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     c,
+				Message:  "License copyright semantics (original author + StepSecurity copyright) must be verified by reviewer.",
+			}
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "LICENSE file present",
+		Severity: SevMust,
+		Status:   StatusFail,
+		Message:  "No LICENSE file found at repo root.",
+	}
+}
+
+func checkActionYMLAuthor(repoPath string) Finding {
+	rule := "common.action_yml_author"
+	for _, name := range []string{"action.yml", "action.yaml"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			continue
+		}
+		author := extractYAMLValue(string(data), "author")
+		if author == "" {
+			return Finding{
+				RuleID:   rule,
+				Title:    "action.yml author field is 'step-security' when present",
+				Severity: SevMust,
+				Status:   StatusSkip,
+				File:     name,
+				Message:  "author field not present in action.yml; rule does not apply.",
+			}
+		}
+		if author == "step-security" {
+			return Finding{
+				RuleID:   rule,
+				Title:    "action.yml author field is 'step-security'",
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     name,
+			}
+		}
+		return Finding{
+			RuleID:   rule,
+			Title:    "action.yml author field is 'step-security'",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     name,
+			Message:  fmt.Sprintf("author=%q (expected: step-security)", author),
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "action.yml author field is 'step-security'",
+		Severity: SevMust,
+		Status:   StatusFail,
+		Message:  "No action.yml or action.yaml found at repo root.",
+	}
+}
+
+func checkSecurityMD(repoPath string) Finding {
+	rule := "common.security_md"
+	for _, c := range []string{"SECURITY.md", ".github/SECURITY.md"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, c))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), "security@stepsecurity.io") {
+			return Finding{
+				RuleID:   rule,
+				Title:    "SECURITY.md present with StepSecurity contact",
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     c,
+			}
+		}
+		return Finding{
+			RuleID:   rule,
+			Title:    "SECURITY.md present with StepSecurity contact",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     c,
+			Message:  "SECURITY.md found but missing 'security@stepsecurity.io' contact line.",
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "SECURITY.md present with StepSecurity contact",
+		Severity: SevMust,
+		Status:   StatusFail,
+		Message:  "No SECURITY.md found at repo root or .github/.",
+	}
+}
+
+func checkRequiredWorkflows(repoPath string) []Finding {
+	required := []struct {
+		Names []string
+		Rule  string
+		Title string
+	}{
+		{Names: []string{"auto_cherry_pick.yml", "auto_cherry_pick.yaml"}, Rule: "common.workflow_auto_cherry_pick", Title: "Workflow .github/workflows/auto_cherry_pick.yml present"},
+		{Names: []string{"actions_release.yml", "actions_release.yaml"}, Rule: "common.workflow_actions_release", Title: "Workflow .github/workflows/actions_release.yml present"},
+	}
+	var findings []Finding
+	for _, req := range required {
+		found := ""
+		for _, n := range req.Names {
+			if _, err := os.Stat(filepath.Join(repoPath, ".github", "workflows", n)); err == nil {
+				found = n
+				break
+			}
+		}
+		if found != "" {
+			findings = append(findings, Finding{
+				RuleID:   req.Rule,
+				Title:    req.Title,
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     filepath.Join(".github/workflows", found),
+			})
+		} else {
+			findings = append(findings, Finding{
+				RuleID:   req.Rule,
+				Title:    req.Title,
+				Severity: SevMust,
+				Status:   StatusFail,
+				Message:  fmt.Sprintf("Missing required workflow %s in .github/workflows/", req.Names[0]),
+			})
+		}
+	}
+	return findings
+}
+
+// checkNoUnauthorizedSchedules enforces that no workflow under
+// .github/workflows/ declares `on.schedule`, with audit_package.yml/.yaml as
+// the sole allowed exception.
+func checkNoUnauthorizedSchedules(repoPath string) []Finding {
+	rule := "common.no_unauthorized_schedule_triggers"
+	title := "No workflow (except audit_package.yml) declares on.schedule"
+	wfDir := filepath.Join(repoPath, ".github", "workflows")
+
+	entries, err := os.ReadDir(wfDir)
+	if err != nil {
+		return []Finding{{
+			RuleID: rule, Title: title,
+			Severity: SevMust, Status: StatusSkip,
+			Message: ".github/workflows/ directory not found.",
+		}}
+	}
+
+	allowed := map[string]bool{
+		"audit_package.yml":  true,
+		"audit_package.yaml": true,
+	}
+
+	var fails []Finding
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".yml" && ext != ".yaml" {
+			continue
+		}
+		if allowed[name] {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(wfDir, name))
+		if err != nil {
+			continue
+		}
+		if hasOnSchedule(string(data)) {
+			fails = append(fails, Finding{
+				RuleID:   rule,
+				Title:    title,
+				Severity: SevMust,
+				Status:   StatusFail,
+				File:     filepath.Join(".github/workflows", name),
+				Message:  "Workflow declares on.schedule; only audit_package.yml may be scheduled.",
+			})
+		}
+	}
+	if len(fails) > 0 {
+		return fails
+	}
+	return []Finding{{
+		RuleID: rule, Title: title,
+		Severity: SevMust, Status: StatusPass,
+	}}
+}
+
+// hasOnSchedule reports whether the workflow YAML declares `schedule` as a
+// trigger under the top-level `on:` key. Handles three forms:
+//
+//	on: schedule                 -> scalar
+//	on: [push, schedule]         -> flow list
+//	on:
+//	  schedule:                  -> block-style child
+//	    - cron: ...
+func hasOnSchedule(content string) bool {
+	lines := strings.Split(content, "\n")
+	inOnBlock := false
+	childIndent := -1
+
+	for _, raw := range lines {
+		trimmed := strings.TrimLeft(raw, " ")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := len(raw) - len(trimmed)
+
+		if indent == 0 {
+			inOnBlock = false
+			childIndent = -1
+
+			if rest, ok := strings.CutPrefix(raw, "on:"); ok {
+				rest = strings.TrimSpace(rest)
+				if i := strings.Index(rest, "#"); i >= 0 {
+					rest = strings.TrimSpace(rest[:i])
+				}
+				if rest == "" {
+					inOnBlock = true
+					continue
+				}
+				// scalar (`on: schedule`) or flow list (`on: [push, schedule]`)
+				rest = strings.Trim(rest, "[]")
+				for part := range strings.SplitSeq(rest, ",") {
+					if strings.TrimSpace(part) == "schedule" {
+						return true
+					}
+				}
+			}
+			continue
+		}
+
+		if !inOnBlock {
+			continue
+		}
+		if childIndent == -1 {
+			childIndent = indent
+		}
+		if indent == childIndent {
+			key := strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[0])
+			if key == "schedule" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type ForbiddenItem struct {
+	Path  string
+	Rule  string
+	Title string
+}
+
+func forbiddenPaths() []ForbiddenItem {
+	mk := func(path, rule string) ForbiddenItem {
+		return ForbiddenItem{Path: path, Rule: rule, Title: "Must not be present: " + path}
+	}
+	return []ForbiddenItem{
+		mk("FUNDING.yml", "common.no_funding_root"),
+		mk("funding.yml", "common.no_funding_root_lower"),
+		mk(".github/FUNDING.yml", "common.no_funding_github"),
+		mk(".github/funding.yml", "common.no_funding_github_lower"),
+		mk("renovate.json", "common.no_renovate_root"),
+		mk(".github/renovate.json", "common.no_renovate_github"),
+		mk("PULL_REQUEST.md", "common.no_pull_request_md_root"),
+		mk(".github/PULL_REQUEST.md", "common.no_pull_request_md_github"),
+		mk(".github/PULL_REQUEST_TEMPLATE.md", "common.no_pull_request_template"),
+		mk(".github/ISSUE_TEMPLATE", "common.no_issue_template_github"),
+		mk("ISSUE_TEMPLATE", "common.no_issue_template_root"),
+		mk("CHANGELOG.md", "common.no_changelog"),
+		mk(".vscode", "common.no_vscode"),
+		mk(".editorconfig", "common.no_editorconfig"),
+		mk(".gitattributes", "common.no_gitattributes"),
+		mk(".github/dependabot.yml", "common.no_dependabot_yml"),
+		mk(".github/dependabot.yaml", "common.no_dependabot_yaml"),
+		mk(".devcontainer", "common.no_devcontainer"),
+		mk("CODE_OF_CONDUCT.md", "common.no_code_of_conduct_root"),
+		mk(".github/CODE_OF_CONDUCT.md", "common.no_code_of_conduct_github"),
+		mk("NOTICE", "common.no_notice"),
+		mk("CONTRIBUTING.md", "common.no_contributing_root"),
+		mk(".github/CONTRIBUTING.md", "common.no_contributing_github"),
+		mk("CODEOWNERS", "common.no_codeowners_root"),
+		mk(".github/CODEOWNERS", "common.no_codeowners_github"),
+		mk("docs/CODEOWNERS", "common.no_codeowners_docs"),
+	}
+}
+
+func checkAbsent(repoPath string, items []ForbiddenItem) []Finding {
+	findings := make([]Finding, 0, len(items))
+	for _, item := range items {
+		p := filepath.Join(repoPath, item.Path)
+		_, err := os.Stat(p)
+		if err == nil {
+			findings = append(findings, Finding{
+				RuleID:   item.Rule,
+				Title:    item.Title,
+				Severity: SevMust,
+				Status:   StatusFail,
+				File:     item.Path,
+				Message:  "File or directory exists and must be removed per StepSecurity onboarding requirements.",
+			})
+		} else {
+			findings = append(findings, Finding{
+				RuleID:   item.Rule,
+				Title:    item.Title,
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     item.Path,
+			})
+		}
+	}
+	return findings
+}
+
+func checkPreCommitTooling(repoPath string) []Finding {
+	var findings []Finding
+
+	forbidden := []ForbiddenItem{
+		{Path: ".husky", Rule: "precommit.no_husky_dir", Title: "Pre-commit: .husky directory absent"},
+		{Path: ".pre-commit-config.yaml", Rule: "precommit.no_pre_commit_config", Title: "Pre-commit: .pre-commit-config.yaml absent"},
+		{Path: ".pre-commit-config.yml", Rule: "precommit.no_pre_commit_config_yml", Title: "Pre-commit: .pre-commit-config.yml absent"},
+		{Path: "lefthook.yml", Rule: "precommit.no_lefthook", Title: "Pre-commit: lefthook.yml absent"},
+		{Path: ".lefthook.yml", Rule: "precommit.no_lefthook_dot", Title: "Pre-commit: .lefthook.yml absent"},
+		{Path: "lefthook-local.yml", Rule: "precommit.no_lefthook_local", Title: "Pre-commit: lefthook-local.yml absent"},
+	}
+	findings = append(findings, checkAbsent(repoPath, forbidden)...)
+
+	// .lintstagedrc* family
+	matches, _ := filepath.Glob(filepath.Join(repoPath, ".lintstagedrc*"))
+	if len(matches) > 0 {
+		for _, m := range matches {
+			rel, _ := filepath.Rel(repoPath, m)
+			findings = append(findings, Finding{
+				RuleID:   "precommit.no_lintstagedrc",
+				Title:    "Pre-commit: no lint-staged config file",
+				Severity: SevMust,
+				Status:   StatusFail,
+				File:     rel,
+				Message:  "lint-staged config file must be removed.",
+			})
+		}
+	} else {
+		findings = append(findings, Finding{
+			RuleID:   "precommit.no_lintstagedrc",
+			Title:    "Pre-commit: no lint-staged config file",
+			Severity: SevMust,
+			Status:   StatusPass,
+		})
+	}
+
+	// package.json: hook deps + husky install scripts
+	if data, err := os.ReadFile(filepath.Join(repoPath, "package.json")); err == nil {
+		s := string(data)
+
+		depRe := regexp.MustCompile(`"(husky|@evilmartians/lefthook|lefthook|lint-staged)"\s*:`)
+		if m := depRe.FindStringSubmatch(s); m != nil {
+			findings = append(findings, Finding{
+				RuleID:   "precommit.package_json_no_hook_deps",
+				Title:    "Pre-commit: package.json has no hook-tooling dependencies",
+				Severity: SevMust,
+				Status:   StatusFail,
+				File:     "package.json",
+				Message:  fmt.Sprintf("Found pre-commit hook tooling dependency: %q", m[1]),
+			})
+		} else {
+			findings = append(findings, Finding{
+				RuleID:   "precommit.package_json_no_hook_deps",
+				Title:    "Pre-commit: package.json has no hook-tooling dependencies",
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     "package.json",
+			})
+		}
+
+		scriptRe := regexp.MustCompile(`"(prepare|postinstall)"\s*:\s*"[^"]*husky[^"]*"`)
+		if m := scriptRe.FindStringSubmatch(s); m != nil {
+			findings = append(findings, Finding{
+				RuleID:   "precommit.package_json_no_husky_install_script",
+				Title:    "Pre-commit: package.json has no husky install script",
+				Severity: SevMust,
+				Status:   StatusFail,
+				File:     "package.json",
+				Message:  fmt.Sprintf("Found husky install script in %q.", m[1]),
+			})
+		} else {
+			findings = append(findings, Finding{
+				RuleID:   "precommit.package_json_no_husky_install_script",
+				Title:    "Pre-commit: package.json has no husky install script",
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     "package.json",
+			})
+		}
+	}
+
+	return findings
+}
+
+func checkBanner(repoPath string) Finding {
+	rule := "common.readme_banner"
+	data, err := os.ReadFile(filepath.Join(repoPath, "README.md"))
+	if err != nil {
+		return Finding{
+			RuleID:   rule,
+			Title:    "README.md banner image present",
+			Severity: SevMust,
+			Status:   StatusFail,
+			Message:  "README.md not found.",
+		}
+	}
+	if strings.Contains(string(data), "maintained-action-banner.png") {
+		return Finding{
+			RuleID:   rule,
+			Title:    "README.md banner image present",
+			Severity: SevMust,
+			Status:   StatusPass,
+			File:     "README.md",
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "README.md banner image present",
+		Severity: SevMust,
+		Status:   StatusFail,
+		File:     "README.md",
+		Message:  "Banner image (maintained-action-banner.png) not referenced in README.md.",
+	}
+}
+
+func checkSubscriptionURL(repoPath string) Finding {
+	rule := "common.subscription_url"
+	hits := grepRepo(repoPath, "agent.api.stepsecurity.io/v1/github", 5)
+	if len(hits) == 0 {
+		return Finding{
+			RuleID:   rule,
+			Title:    "Subscription check URL present in codebase",
+			Severity: SevMust,
+			Status:   StatusFail,
+			Message:  "No reference to 'agent.api.stepsecurity.io/v1/github' found in repo. Subscription check is missing.",
+		}
+	}
+	endpointHits := grepRepo(repoPath, "maintained-actions-subscription", 5)
+	if len(endpointHits) == 0 {
+		return Finding{
+			RuleID:   rule,
+			Title:    "Subscription check uses /maintained-actions-subscription endpoint",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     strings.Join(hits, ", "),
+			Message:  "Subscription URL found but does not use '/maintained-actions-subscription' endpoint. The older '/subscription' endpoint is deprecated.",
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "Subscription check URL present",
+		Severity: SevMust,
+		Status:   StatusPass,
+		File:     strings.Join(endpointHits, ", "),
+		Message:  "Subscription check semantics (invoked first, errors handled correctly) must be verified by reviewer.",
+	}
+}
+
+func checkSubscriptionUpstream(repoPath, upstream string) Finding {
+	rule := "common.subscription_upstream_value"
+	if upstream == "" {
+		return Finding{
+			RuleID:   rule,
+			Title:    "Subscription check upstream matches auto_cherry_pick.yml",
+			Severity: SevMust,
+			Status:   StatusSkip,
+			Message:  "Could not extract original-owner/repo-name from auto_cherry_pick.yml; cannot verify subscription check upstream value.",
+		}
+	}
+	hits := grepRepo(repoPath, upstream, 5)
+	if len(hits) == 0 {
+		return Finding{
+			RuleID:   rule,
+			Title:    "Subscription check upstream matches auto_cherry_pick.yml",
+			Severity: SevMust,
+			Status:   StatusFail,
+			Message:  fmt.Sprintf("Expected upstream %q (from auto_cherry_pick.yml) not found anywhere in code. Subscription check 'upstream' variable likely has the wrong value.", upstream),
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "Subscription check upstream matches auto_cherry_pick.yml",
+		Severity: SevMust,
+		Status:   StatusPass,
+		File:     strings.Join(hits, ", "),
+		Message:  fmt.Sprintf("Upstream %q referenced in repo.", upstream),
+	}
+}
+
+func checkDocsUpstreamRefs(repoPath, upstream string) Finding {
+	rule := "common.docs_upstream_refs"
+	if upstream == "" {
+		return Finding{
+			RuleID:   rule,
+			Title:    "Docs do not reference upstream owner/repo as the action",
+			Severity: SevShould,
+			Status:   StatusSkip,
+			Message:  "Could not extract upstream; skipping docs upstream-reference check.",
+		}
+	}
+	re := regexp.MustCompile(`uses:\s*` + regexp.QuoteMeta(upstream) + `(@|[\s/])`)
+	var hits []string
+	for _, f := range []string{"README.md", "docs/README.md", "USAGE.md"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, f))
+		if err != nil {
+			continue
+		}
+		if re.MatchString(string(data)) {
+			hits = append(hits, f)
+		}
+	}
+	if len(hits) > 0 {
+		return Finding{
+			RuleID:   rule,
+			Title:    "Docs use step-security/<action> in usage examples (not upstream)",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     strings.Join(hits, ", "),
+			Message:  fmt.Sprintf("Found `uses: %s@...` in docs. Should be `uses: step-security/<action-name>@...`.", upstream),
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "Docs use step-security/<action> in usage examples (not upstream)",
+		Severity: SevMust,
+		Status:   StatusPass,
+	}
+}
+
+// ---------- helpers ----------
+
+// grepRepo searches the repo for `pattern`, skipping common heavy/irrelevant
+// directories. Returns up to `maxHits` relative file paths that contain it.
+func grepRepo(repoPath, pattern string, maxHits int) []string {
+	skipDirs := map[string]bool{
+		".git":         true,
+		"node_modules": true,
+		"dist":         true,
+		".yarn":        true,
+		"vendor":       true,
+		"build":        true,
+		"coverage":     true,
+	}
+	skipExt := map[string]bool{
+		".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".pdf": true,
+		".zip": true, ".tar": true, ".gz": true, ".ico": true, ".woff": true,
+		".woff2": true, ".ttf": true, ".eot": true, ".svg": true,
+	}
+	var hits []string
+	_ = filepath.Walk(repoPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if skipExt[strings.ToLower(filepath.Ext(path))] {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		if strings.Contains(string(data), pattern) {
+			rel, _ := filepath.Rel(repoPath, path)
+			hits = append(hits, rel)
+			if maxHits > 0 && len(hits) >= maxHits {
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	return hits
+}
+
+// ---------- node-specific checks ----------
+
+func runNodeChecks(repoPath string) []Finding {
+	var findings []Finding
+	findings = append(findings, checkDistPresent(repoPath))
+	findings = append(findings, checkNpmrcMinReleaseAge(repoPath))
+	findings = append(findings, checkActionYMLNodeVersion(repoPath))
+	findings = append(findings, checkPackageJSONFields(repoPath)...)
+	return findings
+}
+
+func checkDistPresent(repoPath string) Finding {
+	rule := "node.dist_present"
+	info, err := os.Stat(filepath.Join(repoPath, "dist"))
+	if err != nil || !info.IsDir() {
+		return Finding{
+			RuleID:   rule,
+			Title:    "dist/ directory present",
+			Severity: SevMust,
+			Status:   StatusFail,
+			Message:  "dist/ directory is missing. Node-based actions must ship a built bundle.",
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "dist/ directory present",
+		Severity: SevMust,
+		Status:   StatusPass,
+		File:     "dist",
+	}
+}
+
+func checkNpmrcMinReleaseAge(repoPath string) Finding {
+	rule := "node.npmrc_min_release_age"
+	data, err := os.ReadFile(filepath.Join(repoPath, ".npmrc"))
+	if err != nil {
+		return Finding{
+			RuleID:   rule,
+			Title:    ".npmrc present with min-release-age=3",
+			Severity: SevMust,
+			Status:   StatusFail,
+			Message:  ".npmrc file missing.",
+		}
+	}
+	re := regexp.MustCompile(`(?m)^\s*min-release-age\s*=\s*3\s*$`)
+	if !re.Match(data) {
+		return Finding{
+			RuleID:   rule,
+			Title:    ".npmrc present with min-release-age=3",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     ".npmrc",
+			Message:  ".npmrc exists but does not contain 'min-release-age=3'.",
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    ".npmrc present with min-release-age=3",
+		Severity: SevMust,
+		Status:   StatusPass,
+		File:     ".npmrc",
+	}
+}
+
+func checkActionYMLNodeVersion(repoPath string) Finding {
+	rule := "node.action_yml_node24"
+	for _, name := range []string{"action.yml", "action.yaml"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			continue
+		}
+		using := strings.ToLower(extractYAMLValue(string(data), "using"))
+		if using == "node24" {
+			return Finding{
+				RuleID:   rule,
+				Title:    "action.yml uses node24 runtime",
+				Severity: SevMust,
+				Status:   StatusPass,
+				File:     name,
+			}
+		}
+		return Finding{
+			RuleID:   rule,
+			Title:    "action.yml uses node24 runtime",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     name,
+			Message:  fmt.Sprintf("runs.using=%q (expected: node24)", using),
+		}
+	}
+	return Finding{
+		RuleID:   rule,
+		Title:    "action.yml uses node24 runtime",
+		Severity: SevMust,
+		Status:   StatusFail,
+		Message:  "action.yml not found.",
+	}
+}
+
+func checkPackageJSONFields(repoPath string) []Finding {
+	authorRule := "node.package_json_author"
+	repoRule := "node.package_json_repository"
+
+	data, err := os.ReadFile(filepath.Join(repoPath, "package.json"))
+	if err != nil {
+		return []Finding{
+			{
+				RuleID: authorRule, Title: "package.json author is step-security (if present)",
+				Severity: SevMust, Status: StatusSkip, Message: "package.json not found.",
+			},
+			{
+				RuleID: repoRule, Title: "package.json repository contains step-security (if present)",
+				Severity: SevMust, Status: StatusSkip, Message: "package.json not found.",
+			},
+		}
+	}
+	var pkg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return []Finding{{
+			RuleID:   "node.package_json_parse",
+			Title:    "package.json parses as JSON",
+			Severity: SevMust,
+			Status:   StatusFail,
+			File:     "package.json",
+			Message:  fmt.Sprintf("Failed to parse package.json: %v", err),
+		}}
+	}
+
+	var findings []Finding
+
+	// author: can be string or object {name, email, url}
+	if raw, ok := pkg["author"]; ok {
+		authorName := ""
+		var asString string
+		if err := json.Unmarshal(raw, &asString); err == nil {
+			authorName = asString
+		} else {
+			var asObj struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(raw, &asObj); err == nil {
+				authorName = asObj.Name
+			}
+		}
+		if strings.Contains(strings.ToLower(authorName), "step-security") {
+			findings = append(findings, Finding{
+				RuleID: authorRule, Title: "package.json author is step-security",
+				Severity: SevMust, Status: StatusPass, File: "package.json",
+			})
+		} else {
+			findings = append(findings, Finding{
+				RuleID: authorRule, Title: "package.json author is step-security",
+				Severity: SevMust, Status: StatusFail, File: "package.json",
+				Message: fmt.Sprintf("package.json author=%q (expected to contain 'step-security')", authorName),
+			})
+		}
+	} else {
+		findings = append(findings, Finding{
+			RuleID: authorRule, Title: "package.json author is step-security (if present)",
+			Severity: SevMust, Status: StatusSkip, File: "package.json",
+			Message: "author field not present in package.json; rule does not apply.",
+		})
+	}
+
+	// repository: string or {url}
+	if raw, ok := pkg["repository"]; ok {
+		repoStr := ""
+		var asString string
+		if err := json.Unmarshal(raw, &asString); err == nil {
+			repoStr = asString
+		} else {
+			var asObj struct {
+				URL string `json:"url"`
+			}
+			if err := json.Unmarshal(raw, &asObj); err == nil {
+				repoStr = asObj.URL
+			}
+		}
+		if strings.Contains(strings.ToLower(repoStr), "step-security") {
+			findings = append(findings, Finding{
+				RuleID: repoRule, Title: "package.json repository contains step-security",
+				Severity: SevMust, Status: StatusPass, File: "package.json",
+			})
+		} else {
+			findings = append(findings, Finding{
+				RuleID: repoRule, Title: "package.json repository contains step-security",
+				Severity: SevMust, Status: StatusFail, File: "package.json",
+				Message: fmt.Sprintf("package.json repository=%q (expected to contain 'step-security')", repoStr),
+			})
+		}
+	} else {
+		findings = append(findings, Finding{
+			RuleID: repoRule, Title: "package.json repository contains step-security (if present)",
+			Severity: SevMust, Status: StatusSkip, File: "package.json",
+			Message: "repository field not present in package.json; rule does not apply.",
+		})
+	}
+
+	return findings
+}
+
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// ---------- docker-specific checks ----------
+
+func runDockerChecks(repoPath string) []Finding {
+	return []Finding{
+		checkDockerWorkflowPresent(repoPath),
+		checkDockerfileJq(repoPath),
+	}
+}
+
+func checkDockerWorkflowPresent(repoPath string) Finding {
+	rule := "docker.workflow_present"
+	for _, name := range []string{"docker.yml", "docker.yaml"} {
+		p := filepath.Join(repoPath, ".github", "workflows", name)
+		if fileExists(p) {
+			return Finding{
+				RuleID: rule, Title: ".github/workflows/docker.yml present",
+				Severity: SevMust, Status: StatusPass,
+				File: filepath.Join(".github/workflows", name),
+			}
+		}
+	}
+	return Finding{
+		RuleID: rule, Title: ".github/workflows/docker.yml present",
+		Severity: SevMust, Status: StatusFail,
+		Message: "docker.yml workflow is required for docker-based actions but was not found in .github/workflows/.",
+	}
+}
+
+// checkDockerfileJq verifies `jq` is installed in the Dockerfile, but only when
+// the Dockerfile's ENTRYPOINT/CMD invokes a shell script (`.sh`). When the
+// entry-point is a JS/TS/Python/Go binary, the subscription check lives in that
+// language and jq isn't required.
+func checkDockerfileJq(repoPath string) Finding {
+	rule := "docker.dockerfile_jq"
+	var dockerfilePath string
+	for _, name := range []string{"Dockerfile", "dockerfile"} {
+		p := filepath.Join(repoPath, name)
+		if fileExists(p) {
+			dockerfilePath = p
+			break
+		}
+	}
+	if dockerfilePath == "" {
+		return Finding{
+			RuleID: rule, Title: "Dockerfile installs jq (when entrypoint is a shell script)",
+			Severity: SevMust, Status: StatusSkip,
+			Message: "No Dockerfile found at repo root.",
+		}
+	}
+	data, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		return Finding{
+			RuleID: rule, Title: "Dockerfile installs jq",
+			Severity: SevMust, Status: StatusSkip,
+			Message: fmt.Sprintf("Failed to read Dockerfile: %v", err),
+		}
+	}
+	content := string(data)
+
+	// detect whether ENTRYPOINT/CMD invokes a .sh script
+	entryRe := regexp.MustCompile(`(?im)^\s*(ENTRYPOINT|CMD)\b.*\.sh\b`)
+	if !entryRe.MatchString(content) {
+		return Finding{
+			RuleID: rule, Title: "Dockerfile installs jq (when entrypoint is a shell script)",
+			Severity: SevMust, Status: StatusSkip,
+			File:    "Dockerfile",
+			Message: "Dockerfile entrypoint/CMD is not a shell script; jq is not required (subscription check lives in the invoked binary).",
+		}
+	}
+
+	jqRe := regexp.MustCompile(`(?i)\bjq\b`)
+	if !jqRe.MatchString(content) {
+		return Finding{
+			RuleID: rule, Title: "Dockerfile installs jq (entrypoint is a shell script)",
+			Severity: SevMust, Status: StatusFail,
+			File:    "Dockerfile",
+			Message: "Dockerfile invokes a shell script via ENTRYPOINT/CMD but does not install jq. The subscription check requires jq.",
+		}
+	}
+	return Finding{
+		RuleID: rule, Title: "Dockerfile installs jq (entrypoint is a shell script)",
+		Severity: SevMust, Status: StatusPass,
+		File: "Dockerfile",
+	}
+}
+
+// ---------- composite-specific checks ----------
+
+func runCompositeChecks(repoPath string) []Finding {
+	return []Finding{checkCompositeFirstStepSubscription(repoPath)}
+}
+
+// checkCompositeFirstStepSubscription checks that the first step under
+// `runs.steps` in action.yml contains the subscription check (i.e. references
+// the agent.api.stepsecurity.io URL).
+func checkCompositeFirstStepSubscription(repoPath string) Finding {
+	rule := "composite.first_step_subscription"
+	for _, name := range []string{"action.yml", "action.yaml"} {
+		data, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			continue
+		}
+		firstStep, ok := extractFirstCompositeStep(string(data))
+		if !ok {
+			return Finding{
+				RuleID: rule, Title: "First composite step is the subscription check",
+				Severity: SevMust, Status: StatusFail, File: name,
+				Message: "Could not locate any steps under runs.steps in action.yml.",
+			}
+		}
+		if strings.Contains(firstStep, "agent.api.stepsecurity.io/v1/github") {
+			return Finding{
+				RuleID: rule, Title: "First composite step is the subscription check",
+				Severity: SevMust, Status: StatusPass, File: name,
+			}
+		}
+		return Finding{
+			RuleID: rule, Title: "First composite step is the subscription check",
+			Severity: SevMust, Status: StatusFail, File: name,
+			Message: "First step under runs.steps does not contain the subscription check URL. The subscription bash snippet must be the first step.",
+		}
+	}
+	return Finding{
+		RuleID: rule, Title: "First composite step is the subscription check",
+		Severity: SevMust, Status: StatusFail,
+		Message: "action.yml not found.",
+	}
+}
+
+// extractFirstCompositeStep returns the YAML block of the first step under
+// `runs.steps`. It is a best-effort regex-based extractor — sufficient for the
+// shape produced by the onboarding spec.
+func extractFirstCompositeStep(content string) (string, bool) {
+	stepsRe := regexp.MustCompile(`(?m)^\s*steps:\s*$`)
+	loc := stepsRe.FindStringIndex(content)
+	if loc == nil {
+		return "", false
+	}
+	after := content[loc[1]:]
+
+	// find first list item (`-` at any indent) after steps:
+	itemRe := regexp.MustCompile(`(?m)^(\s*)-\s`)
+	itemLoc := itemRe.FindStringSubmatchIndex(after)
+	if itemLoc == nil {
+		return "", false
+	}
+	indent := after[itemLoc[2]:itemLoc[3]]
+	start := itemLoc[0]
+
+	// find the next list item at the same indent (or a sibling top-level key) to bound the step
+	endRe := regexp.MustCompile(fmt.Sprintf(`(?m)^%s-\s|^[A-Za-z]`, regexp.QuoteMeta(indent)))
+	endLoc := endRe.FindStringIndex(after[itemLoc[1]:])
+	if endLoc == nil {
+		return after[start:], true
+	}
+	return after[start : itemLoc[1]+endLoc[0]], true
+}

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,11 @@ require (
 	golang.org/x/oauth2 v0.30.0
 )
 
-require github.com/google/go-querystring v1.1.0 // indirect
+require (
+	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/jedib0t/go-pretty/v6 v6.8.1 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,17 @@ github.com/google/go-github/v57 v57.0.0 h1:L+Y3UPTY8ALM8x+TV0lg+IEBI+upibemtBD8Q
 github.com/google/go-github/v57 v57.0.0/go.mod h1:s0omdnye0hvK/ecLvpsGfJMiRt85PimQh4oygmLIxHw=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/jedib0t/go-pretty/v6 v6.8.1 h1:0fkCNhjrX0zPpwkWaDYU5VMrygg41Tu197mWILIJoqQ=
+github.com/jedib0t/go-pretty/v6 v6.8.1/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Replace the single-prompt onboarding review with a two-stage flow: a Go tool runs ~50 deterministic compliance checks and emits JSON; the Claude action reads that report and focuses only on judgment calls (license semantics, control-flow reasoning, security review, advisor swaps). Boolean compliance is now reproducible, CI-gate-able, and runnable locally before opening a PR. Claude's tokens go to real judgment instead of file-presence checks.

**cmd/review-onboarding (new)**: detects action type and upstream from auto_cherry_pick.yml, then runs deterministic rules across four categories.

  **Common**: `LICENSE`, `action.yml` author, `SECURITY.md` contact, 22
  forbidden files/dirs (`FUNDING`, `renovate`, `PULL_REQUEST`,
  `ISSUE_TEMPLATE`, `CHANGELOG`, .`vscode`, `.editorconfig`, .`gitattributes`,
  dependabot, .devcontainer, CODE_OF_CONDUCT, NOTICE, CONTRIBUTING,
  `CODEOWNERS` at multiple paths), required workflows present,
  pre-commit tooling absent (husky/lefthook/pre-commit/lint-staged,
  including package.json deps and install scripts), `README` banner,
  subscription URL using new `/maintained-actions-subscription`
  endpoint, subscription upstream matches `auto_cherry_pick.yml`, docs
  do not reference upstream owner/repo, no on.schedule trigger
  outside `audit_package.yml`.

  **Node**: dist/ present, .npmrc has min-release-age=3, action.yml
  runs.using=node24, package.json author/repository contain
  step-security (skipped when fields absent).

  **Docker**: .github/workflows/docker.yml exists; jq installed in
  Dockerfile when ENTRYPOINT/CMD invokes a .sh script (skipped
  otherwise, since the check then lives in the invoked binary).

  **Composite**: first step under runs.steps in action.yml contains the
  subscription URL.

**CLI**: --repo-path, --output (default stdout), --format/-f json|table (default json; table uses go-pretty/v6 with colored status and word-wrap, colors auto-strip when writing to a file), --fail-on-error. Summary always goes to stderr so stdout stays pipeable into jq.

**.github/workflows/claude_review.yml**: the onboarding path (gated on the existing review-required label) now checks out step-security/reusable-workflows, sets up Go, runs the tool to produce review_report.json, uploads the artifact, and appends a failure table to $GITHUB_STEP_SUMMARY. The Claude direct_prompt was rewritten to (1) read the JSON, (2) spot-check a few tool decisions for regex errors, (3) cover only the rules the tool cannot - license copyright semantics, subscription invoked first, upstream-only workflow classification, latest-major + advisor swaps for `uses:` references, README major-version tags, security scan, and the action-type-specific judgment items (node workflow inputs, docker subscription-check file location, composite action pinning) - then emit a fixed-shape markdown PR comment. The cherry-pick path is untouched.

go.mod: adds github.com/jedib0t/go-pretty/v6 (same library OSV-Scanner uses) for terminal-table rendering.